### PR TITLE
Add support for nginxinc

### DIFF
--- a/.github/workflows/release-and-pr-kubernetes-ingress.yml
+++ b/.github/workflows/release-and-pr-kubernetes-ingress.yml
@@ -1,0 +1,88 @@
+name: Produce Docker Image, GH Release & Create PR for Override File
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 13 * * 1-5' # M-F at 6 AM PDT
+
+jobs:
+  # Compare kubernetes/ingress-nginx version with sigsci-nginx-ingress-controller version
+  # If new version build and push container to docker hub
+  # Create and tag new release
+  # Update sigsci-value.yaml file & create PR
+  compare_versions:
+    runs-on: ubuntu-latest
+    env:
+      GH_REPO: https://api.github.com/repos/signalsciences/sigsci-nginx-ingress-controller
+    outputs:
+      value: ${{ steps.tag.outputs.NO_CHANGE }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_API_TOKEN }}
+    - name: compare versions
+      id: tag
+      env:
+        REPO: signalsciences/sigsci-nginx-ingress-controller
+      run: |
+        INGRESS_LATEST=$(curl -sL https://api.github.com/repos/kubernetes/ingress-nginx/releases | grep "tag_name" | grep -m1 "controller" | cut -d '"' -f4 | cut -d 'v' -f2)
+        SIGSCI_LATEST=$(curl -sL ${{ env.GH_REPO }}/releases | grep "tag_name" | grep -m1 "tag_name" | cut -d '"' -f4)
+
+        version() { echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'; }
+
+        if [ $(version $INGRESS_LATEST) -eq $(version $SIGSCI_LATEST) ]; then
+          echo "ingress-nginx version: $INGRESS_LATEST -- matches sigsci version: $SIGSCI_LATEST"
+          echo "::set-output name=NO_CHANGE::true"
+        else
+          TAG=$INGRESS_LATEST
+          docker build . --file Dockerfile --build-arg NGINX_INGRESS_VERSION=v${TAG} --tag ${REPO}:${TAG}
+          docker push ${REPO}:${TAG}
+          echo NEW_TAG=$TAG >> $GITHUB_ENV
+          echo "::set-output name=NO_CHANGE::false"
+        fi
+    
+    - name: Create Release
+      if: ${{ steps.tag.outputs.NO_CHANGE == 'false' }}
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ env.NEW_TAG }}
+        release_name: Match release ${{ env.NEW_TAG }}
+        body: |
+         Match release kubernetes/ingress-nginx v${{ env.NEW_TAG }} 
+        draft: false
+        prerelease: false
+
+    - name: Update sigsci-values.yaml & create PR
+      if: ${{ steps.tag.outputs.NO_CHANGE == 'false' }}
+      run: |
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git checkout -b match-version-release
+        sed -i "s/tag:.*/tag: \"${{ env.NEW_TAG }}\"/g" sigsci-values.yaml
+        git commit -am "Automated PR - Match upstream version" && git push -u origin match-version-release
+
+        curl -X POST -u ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} \
+        ${{ env.GH_REPO }}/pulls --data '{"head":"match-version-release","base":"main","body":"Automated PR","title":"Match Version ${{ env.NEW_TAG}}"}'
+
+    - name: Pull latest PR Num
+      if: ${{ steps.tag.outputs.NO_CHANGE == 'false' }}
+      run: |
+        pr_number=$(curl -s \
+        -H "Accept: application/vnd.github.v3+json" \
+        -u ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} \
+        ${{ env.GH_REPO }}/pulls | jq -r '.[].number')
+        echo PR_NUM=$pr_number >> $GITHUB_ENV
+
+    - name: Add reviewers to latest PR
+      if: ${{ steps.tag.outputs.NO_CHANGE == 'false' }}
+      run: |
+        curl -s \
+        -H "Accept: application/vnd.github.v3+json" \
+        -u ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} \
+        ${{ env.GH_REPO }}/pulls/${{ env.PR_NUM }}/requested_reviewers \
+        --data '{"reviewers":["bbucher-sigsci","leaf-fastly","rell-fastly"]}'

--- a/.github/workflows/release-and-pr-nginxinc-ingress.yml
+++ b/.github/workflows/release-and-pr-nginxinc-ingress.yml
@@ -3,17 +3,18 @@ name: Produce Docker Image, GH Release & Create PR for Override File
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 13 * * 1-5' # M-F at 6 AM PDT
+    - cron: '0 15 * * 1-5' # M-F at 8 AM PDT
 
 jobs:
-  # Compare kubernetes/ingress-nginx version with sigsci-nginx-ingress-controller version
+  # Compare nginxinc/kubernetes-ingress version with sigsci-nginx-ingress-controller version
   # If new version build and push container to docker hub
   # Create and tag new release
-  # Update sigsci-value.yaml file & create PR
+  # Update sigsci-nginxinc-value.yaml file & create PR
   compare_versions:
     runs-on: ubuntu-latest
     env:
       GH_REPO: https://api.github.com/repos/signalsciences/sigsci-nginx-ingress-controller
+      VALUES_FILE: sigsci-nginxinc-values.yaml
     outputs:
       value: ${{ steps.tag.outputs.NO_CHANGE }}
     steps:
@@ -26,19 +27,19 @@ jobs:
     - name: compare versions
       id: tag
       env:
-        REPO: signalsciences/sigsci-nginx-ingress-controller
+        REPO: signalsciences/sigsci-nginxinc-nginx-ingress-controller
       run: |
-        INGRESS_LATEST=$(curl -sL https://api.github.com/repos/kubernetes/ingress-nginx/releases | grep "tag_name" | grep -m1 "controller" | cut -d '"' -f4 | cut -d 'v' -f2)
+        NGINXINC_INGRESS_LATEST="$(curl -sL https://api.github.com/repos/nginxinc/kubernetes-ingress/releases | grep "tag_name" -m1 | cut -d '"' -f4 | cut -d 'v' -f2)"
         SIGSCI_LATEST=$(curl -sL ${{ env.GH_REPO }}/releases | grep "tag_name" | grep -m1 "tag_name" | cut -d '"' -f4)
 
         version() { echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'; }
 
-        if [ $(version $INGRESS_LATEST) -eq $(version $SIGSCI_LATEST) ]; then
-          echo "ingress-nginx version: $INGRESS_LATEST -- matches sigsci version: $SIGSCI_LATEST"
+        if [ $(version $NGINXINC_INGRESS_LATEST) -eq $(version $SIGSCI_LATEST) ]; then
+          echo "ingress-nginx version: $NGINXINC_INGRESS_LATEST -- matches sigsci version: $SIGSCI_LATEST"
           echo "::set-output name=NO_CHANGE::true"
         else
-          TAG=$INGRESS_LATEST
-          docker build . --file Dockerfile --build-arg NGINX_INGRESS_VERSION=v${TAG} --tag ${REPO}:${TAG}
+          TAG=$NGINXINC_INGRESS_LATEST
+          docker build . --file Dockerfile.nginxinc --build-arg NGINX_INGRESS_VERSION=${TAG} --tag ${REPO}:${TAG}
           docker push ${REPO}:${TAG}
           echo NEW_TAG=$TAG >> $GITHUB_ENV
           echo "::set-output name=NO_CHANGE::false"
@@ -53,17 +54,17 @@ jobs:
         tag_name: ${{ env.NEW_TAG }}
         release_name: Match release ${{ env.NEW_TAG }}
         body: |
-         Match release kubernetes/ingress-nginx v${{ env.NEW_TAG }} 
+         Match release nginxinc/kubernetes-ingress v${{ env.NEW_TAG }}
         draft: false
         prerelease: false
 
-    - name: Update sigsci-values.yaml & create PR
+    - name: Update ${{ env.VALUES_FILE }} & create PR
       if: ${{ steps.tag.outputs.NO_CHANGE == 'false' }}
       run: |
         git config --local user.email "github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
         git checkout -b match-version-release
-        sed -i "s/tag:.*/tag: \"${{ env.NEW_TAG }}\"/g" sigsci-values.yaml
+        sed -i "s/tag:.*/tag: \"${{ env.NEW_TAG }}\"/g" ${{ env.VALUES_FILE }}
         git commit -am "Automated PR - Match upstream version" && git push -u origin match-version-release
 
         curl -X POST -u ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} \
@@ -85,4 +86,4 @@ jobs:
         -H "Accept: application/vnd.github.v3+json" \
         -u ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} \
         ${{ env.GH_REPO }}/pulls/${{ env.PR_NUM }}/requested_reviewers \
-        --data '{"reviewers":["lsmith-fastly","bbucher-sigsci","leaf-fastly","rell-fastly","andy-fastly"]}'
+        --data '{"reviewers":["bbucher-sigsci","leaf-fastly","rell-fastly","andy-fastly"]}'

--- a/.github/workflows/release-and-pr-nginxinc-ingress.yml
+++ b/.github/workflows/release-and-pr-nginxinc-ingress.yml
@@ -27,7 +27,7 @@ jobs:
     - name: compare versions
       id: tag
       env:
-        REPO: signalsciences/sigsci-nginxinc-nginx-ingress-controller
+        REPO: signalsciences/sigsci-nginxinc-ingress-controller
       run: |
         NGINXINC_INGRESS_LATEST="$(curl -sL https://api.github.com/repos/nginxinc/kubernetes-ingress/releases | grep "tag_name" -m1 | cut -d '"' -f4 | cut -d 'v' -f2)"
         SIGSCI_LATEST=$(curl -sL ${{ env.GH_REPO }}/releases | grep "tag_name" | grep -m1 "tag_name" | cut -d '"' -f4)
@@ -86,4 +86,4 @@ jobs:
         -H "Accept: application/vnd.github.v3+json" \
         -u ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} \
         ${{ env.GH_REPO }}/pulls/${{ env.PR_NUM }}/requested_reviewers \
-        --data '{"reviewers":["bbucher-sigsci","leaf-fastly","rell-fastly","andy-fastly"]}'
+        --data '{"reviewers":["bbucher-sigsci","leaf-fastly","rell-fastly"]}'

--- a/.github/workflows/release-and-pr-nginxinc-ingress.yml
+++ b/.github/workflows/release-and-pr-nginxinc-ingress.yml
@@ -1,4 +1,4 @@
-name: Produce Docker Image, GH Release & Create PR for Override File
+name: Produce Docker Image with nginxinc upstream support, GH Release & Create PR for Override File
 
 on:
   workflow_dispatch:

--- a/Dockerfile.nginxinc
+++ b/Dockerfile.nginxinc
@@ -1,5 +1,5 @@
 ARG NGINX_INGRESS_VERSION=${NGINX_INGRESS_VERSION:-2.2.0-alpine}
-FROM ghcr.io/nginxinc/kubernetes-ingress:${NGINX_INGRESS_VERSION}
+FROM nginx/nginx-ingress:${NGINX_INGRESS_VERSION}
 ARG PKGNAME=${PKGNAME:-nginx-module-sigsci-nxo}
 
 # Change to the root user to update the container

--- a/Dockerfile.nginxinc
+++ b/Dockerfile.nginxinc
@@ -1,0 +1,29 @@
+ARG NGINX_INGRESS_VERSION=${NGINX_INGRESS_VERSION:-2.2.0-alpine}
+FROM ghcr.io/nginxinc/kubernetes-ingress:${NGINX_INGRESS_VERSION}
+ARG PKGNAME=${PKGNAME:-nginx-module-sigsci-nxo}
+
+# Change to the root user to update the container
+USER root
+
+# Install Signal Sciences dependencies and nginx native module
+# NOTE: The nginx native module to be installed needs to be for
+#       the correct version of nginx installed; this applies
+#       to both nginx.org and openresty nginx distributions.
+RUN apk update && apk add --no-cache gnupg wget --virtual ./build_deps \
+    # Figure out which alpine release this is
+    && ALPINE_RELEASE=$(cat /etc/alpine-release) \
+    && ALPINE_RELEASE=${ALPINE_RELEASE::-2} \
+    # Figure out which nginx is installed in the container
+    && NGXVERSION=$(nginx -v 2>&1 | sed 's%^[^/]*/\([0-9]*\.[0-9]*\.[0-9]*\).*%\1%') \
+    # Get the latest version of the sigsci nginx native module
+    && MODULE_VERSION=$(wget -O- -q https://dl.signalsciences.net/sigsci-module-nginx-native/VERSION) \
+    # Get the correct sigsci nginx native module based on alpine version, nginx version, and module version
+    && wget https://apk.signalsciences.net/sigsci_apk.pub && mv sigsci_apk.pub /etc/apk/keys \
+    && echo "https://apk.signalsciences.net/${ALPINE_RELEASE}/main" | tee -a /etc/apk/repositories \
+    && apk add ${PKGNAME}-${NGXVERSION} \
+    && sed -i 's@^pid.*@&\nload_module /usr/lib/nginx/modules/ngx_http_sigsci_module.so;\n@' /etc/nginx/nginx.conf \
+    # cleanup
+    && apk del --no-cache ./build_deps \
+    && rm /etc/apk/keys/sigsci_apk.pub
+# Change back to the www-data user for executing nginx at runtime
+USER www-data

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Tags/Releases track image tags of the upstream docker repo.
 These images work as drop-in replacements for:
 * `k8s.gcr.io/ingress-nginx/controller` images with corresponding tags (0.43.0)
 * `quay.io/kubernetes-ingress-controller/nginx-ingress-controller` images with corresponding tags (0.25.0-0.33.0)
+
+Use `Dockerfile.nginxinc` if you want to add the Signal Sciences NGINX module into the stock nginxinc/kubernetes-ingress image (https://github.com/nginxinc/kubernetes-ingress)
+
+Prebuilt images are hosted here: https://hub.docker.com/repository/docker/signalsciences/sigsci-nginxinc-ingress-controller
+
+Tags/Releases are also used to track the tags of the upstream repo:
 * `nginx/nginx-ingress` images with corresponding tags (>= 2.2.0)
 
 ## Helm install instructions with override file
@@ -49,12 +55,57 @@ spec:
               number: 80
 ```
 
+Follow these steps to install [nginxinc/kubernetes-ingress](https://github.com/nginxinc/kubernetes-ingress) with the sigsci-nginxinc-values.yaml override file. This will add the custom sigsci-nginx-ingress-controller and sigsci-agent.
+
+1) Add the [nginxinc/kubernetes-ingress](https://github.com/nginxinc/kubernetes-ingress/tree/main/deployments/helm-chart) repo  
+   `helm repo add nginx-stable https://helm.nginx.com/stable`
+
+2) Add `SIGSCI_ACCESSKEYID` and `SIGSCI_SECRETACCESSKEY` to the [sigsci-nginxinc-values.yaml](sigsci-nginxinc-values.yaml) file.
+
+3) Install with helm  
+   `helm install -f sigsci-nginxinc-values.yaml my-ingress nginx-stable/nginx-ingress`
+* You can specify a namespace with `-n` flag:  
+  `helm install -n NAMESPACE -f sigsci-nginxinc-values.yaml my-ingress nginx-stable/nginx-ingress`
+
+4) Create an Ingress resource. This step will vary depending on setup and supports a lot of configurations. Official documentation can be found regarding [Basic usage - host based routing](https://kubernetes.github.io/ingress-nginx/user-guide/basic-usage/)
+
+Here is an example Ingress file for the nginxinc/kubernetes-ingress controller:
+```
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cafe-ingress
+spec:
+  tls:
+  - hosts:
+    - cafe.example.com
+    secretName: cafe-secret
+  rules:
+  - host: cafe.example.com
+    http:
+      paths:
+      - path: /tea
+        pathType: Prefix
+        backend:
+          service:
+            name: tea-svc
+            port:
+              number: 80
+      - path: /coffee
+        pathType: Prefix
+        backend:
+          service:
+            name: coffee-svc
+            port:
+              number: 80
+```
+
 5) Now you are ready to setup rules, rate limits and more [using Signal Sciences](https://docs.fastly.com/signalsciences/using-signal-sciences/)
 
 ## Helm Upgrade with Override File
-To update the [ingress-nginx charts](https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx) 
+To update the [ingress-nginx charts](https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx) or [kubernetes-ingress charts](https://github.com/nginxinc/kubernetes-ingress/tree/main/deployments/helm-chart)
 
-1. Update the sigsci-nginx-ingress-controller to the latest version in the [sigsci-values.yaml](https://github.com/signalsciences/sigsci-nginx-ingress-controller/blob/main/sigsci-values.yaml) file
+1. Update the sigsci-nginx-ingress-controller to the latest version in the [sigsci-values.yaml](https://github.com/signalsciences/sigsci-nginx-ingress-controller/blob/main/sigsci-values.yaml) or [sigsci-nginxinc-values.yaml](https://github.com/signalsciences/sigsci-nginx-ingress-controller/blob/main/sigsci-nginxinc-values.yaml) file
 ```
 controller:
     # Replaces the default nginx-controller image with a custom image that contains the Signal Sciences nginx Module
@@ -65,9 +116,11 @@ controller:
 ```
 
 2. Then run helm upgrade with override file. This example is running helm upgrade against the `my-ingress` release created in step 3 of the previous section.  
-`helm upgrade -f sigsci-values.yaml my-ingress ingress-nginx/ingress-nginx`
+`helm upgrade -f sigsci-values.yaml my-ingress ingress-nginx/ingress-nginx` or
+`helm upgrade -f sigsci-nginxinc-values.yaml my-ingress nginx-stable/nginx-ingress` depending on your upstream ingress controller
 * If ingress is not in default namespace use `-n` to specify namespace:  
-`helm upgrade -n NAMESPACE -f sigsci-values.yaml my-ingress ingress-nginx/ingress-nginx`
+`helm upgrade -n NAMESPACE -f sigsci-values.yaml my-ingress ingress-nginx/ingress-nginx` or
+`helm upgrade -n NAMESPACE -f sigsci-nginxinc-values.yaml my-ingress nginx-stable/nginx-ingress`
 
 
 ## Uninstall Release

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Tags/Releases track image tags of the upstream docker repo.
 These images work as drop-in replacements for:
 * `k8s.gcr.io/ingress-nginx/controller` images with corresponding tags (0.43.0)
 * `quay.io/kubernetes-ingress-controller/nginx-ingress-controller` images with corresponding tags (0.25.0-0.33.0)
+* `nginx/nginx-ingress` images with corresponding tags (>= 2.2.0)
 
 ## Helm install instructions with override file
 

--- a/sigsci-nginxinc-values.yaml
+++ b/sigsci-nginxinc-values.yaml
@@ -2,7 +2,7 @@ controller:
 
   image:
     ## Replaces the default nginx-controller image with a custom image that contains the Signal Sciences nginx Module
-    repository: signalsciences/sigsci-nginxinc-nginx-ingress-controller
+    repository: signalsciences/sigsci-nginxinc-ingress-controller
     tag: "2.2.0"
     pullPolicy: IfNotPresent
 

--- a/sigsci-nginxinc-values.yaml
+++ b/sigsci-nginxinc-values.yaml
@@ -1,0 +1,38 @@
+controller:
+
+  image:
+    ## Replaces the default nginx-controller image with a custom image that contains the Signal Sciences nginx Module
+    repository: signalsciences/sigsci-nginxinc-nginx-ingress-controller
+    tag: "2.2.0"
+    pullPolicy: IfNotPresent
+
+  # Load module and set sigsci_agent_host
+  config:
+    entries:
+      main-snippets: load_module /usr/lib/nginx/modules/ngx_http_sigsci_module.so;
+      http-snippets: sigsci_agent_host unix:/sigsci/tmp/sigsci.sock;
+
+  ## The volumes of the Ingress Controller pods.
+  volumes:
+    - name: sigsci-temp
+
+  # Mounts shared volume for sigsci.sock file
+  volumeMounts:
+    - name: sigsci-temp
+      mountPath: /sigsci/tmp
+
+  # Loads sidecar Signal Sciences Agent
+  extraContainers:
+    - name: sigsci-agent
+      image: signalsciences/sigsci-agent:latest
+      volumeMounts:
+        - name: sigsci-temp
+          mountPath: /sigsci/tmp
+      # Sets Signal Sciences Agent keys and SigSci RPC address
+      env:
+        - name: SIGSCI_RPC_ADDRESS
+          value: unix:/sigsci/tmp/sigsci.sock
+        - name: SIGSCI_ACCESSKEYID
+          value: SET_ME
+        - name: SIGSCI_SECRETACCESSKEY
+          value: SET_ME


### PR DESCRIPTION
This PR will add support for using the [nginxinc ingress controller](https://github.com/nginxinc/kubernetes-ingress).

I'm following the same process that already exists for supporting [kubernetes nginx ingress controller](https://github.com/kubernetes/ingress-nginx).

TODO:
* need to add additional information to the README, and customer docs (they're both the same.)

I'd like to merge these changes in order to see the workflow run in Github. I've already tested the workflow locally with [nektos](https://github.com/nektos/act), which passed.