### PR TITLE
Bump tag to latest(1.3.0) upstream version to match what is in dockerhub

### DIFF
--- a/sigsci-values.yaml
+++ b/sigsci-values.yaml
@@ -2,7 +2,7 @@ controller:
     # Replaces the default nginx-controller image with a custom image that contains the Signal Sciences nginx Module
     image:
       repository: signalsciences/sigsci-nginx-ingress-controller
-      tag: "1.2.1"
+      tag: "1.3.0"
       pullPolicy: IfNotPresent
 
     # Load module and set sigsci_agent_host


### PR DESCRIPTION
Just updating the tag to match the Github release version and image version in dockerhub