### PR TITLE
disable running workflow schedule

### DIFF
--- a/.github/workflows/release-and-pr-nginxinc-ingress.yml
+++ b/.github/workflows/release-and-pr-nginxinc-ingress.yml
@@ -2,8 +2,6 @@ name: Produce Docker Image with nginxinc upstream support, GH Release & Create P
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 15 * * 1-5' # M-F at 8 AM PDT
 
 jobs:
   # Compare nginxinc/kubernetes-ingress version with sigsci-nginx-ingress-controller version


### PR DESCRIPTION
This workflow is currently failing. 
Given that there have only been 30 total downloads of this container on dockerhub, I'd like to leave this workflow, but only allow for manually running it. This gives us the ability to build for the nginx/nginx-ingress controller if we need to. 
We currently support the predominant upstream nginx-ingress controller which is the kubernetes controller.