### PR TITLE
Manual Release for Nginxinc

### DIFF
--- a/.github/workflows/manual-nginxinc.yml
+++ b/.github/workflows/manual-nginxinc.yml
@@ -13,20 +13,16 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_API_TOKEN }}
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v4
         with:
           build-args: |

--- a/.github/workflows/manual-nginxinc.yml
+++ b/.github/workflows/manual-nginxinc.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
-             
+
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -39,7 +39,7 @@ jobs:
           push: true
           tags: >-
             ${{ env.DOCKERHUB_IMAGE }}:${{ env.UPSTREAM_NGINX_INGRESS_VERSION }},${{ env.DOCKERHUB_IMAGE}}:latest,
- 
+
       - name: Echo output
         run: >-
           echo "::set-output

--- a/.github/workflows/manual-nginxinc.yml
+++ b/.github/workflows/manual-nginxinc.yml
@@ -3,19 +3,34 @@ name: Manual Push NginxInc Image to DockerHub
 on:
   workflow_dispatch:
 
+env:
+  LATEST_TAG: signalsciences/sigsci-nginxinc-ingress-controller:latest
+  VERSION_TAG: signalsciences/sigsci-nginxinc-ingress-controller:2.3.0
+
 jobs:
-  deploy:
+  docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_API_TOKEN }}
-      - name: Build and Push image to docker Hub
-        env:
-          TAG: 2.3.0
-          REPO: signalsciences/sigsci-nginx-ingress-controller
-        run: |
-          docker buildx build . --file Dockerfile.nginxinc --build-arg NGINX_INGRESS_VERSION=${TAG} --tag ${REPO}:${TAG} --tag ${REPO}:latest --push .
+      -
+        name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          build-args: |
+            NGINX_INGRESS_VERSION=2.3.0
+            CONTAINER_BASE=alpine
+          context: .
+          file: Dockerbuild.nginxinc
+          push: true
+          tags: ${{ env.LATEST_TAG }}, ${{ env.VERSION_TAG }}

--- a/.github/workflows/manual-nginxinc.yml
+++ b/.github/workflows/manual-nginxinc.yml
@@ -4,31 +4,43 @@ on:
   workflow_dispatch:
 
 env:
-  LATEST_TAG: signalsciences/sigsci-nginxinc-ingress-controller:latest
-  VERSION_TAG: signalsciences/sigsci-nginxinc-ingress-controller:2.3.0
-  UPSTREAM_NGINX_INGRESS_VERSION: 2.3.0
+  DOCKERHUB_IMAGE: signalsciences/sigsci-nginxinc-ingress-controller
   DISTRIBUTION: alpine
+  UPSTREAM_NGINX_INGRESS_VERSION: 2.3.0
 
 jobs:
-  docker:
+  buildpush_to_dockerhub:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v2
+             
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_API_TOKEN }}
+
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: .
+          file: Dockerfile.nginxinc
           build-args: |
             NGINX_INGRESS_VERSION=${{ env.UPSTREAM_NGINX_INGRESS_VERSION }}
             CONTAINER_BASE=${{ env.DISTRIBUTION }}
-          context: .
-          file: Dockerbuild.nginxinc
           push: true
-          tags: ${{ env.LATEST_TAG }}, ${{ env.VERSION_TAG }}
+          tags: >-
+            ${{ env.DOCKERHUB_IMAGE }}:${{ env.UPSTREAM_NGINX_INGRESS_VERSION }},${{ env.DOCKERHUB_IMAGE}}:latest,
+ 
+      - name: Echo output
+        run: >-
+          echo "::set-output
+          name=image::${{ env.DOCKERHUB_IMAGE}}:latest,${{ env.DOCKERHUB_IMAGE }}:${{ env.UPSTREAM_NGINX_INGRESS_VERSION }}"

--- a/.github/workflows/manual-nginxinc.yml
+++ b/.github/workflows/manual-nginxinc.yml
@@ -6,6 +6,8 @@ on:
 env:
   LATEST_TAG: signalsciences/sigsci-nginxinc-ingress-controller:latest
   VERSION_TAG: signalsciences/sigsci-nginxinc-ingress-controller:2.3.0
+  UPSTREAM_NGINX_INGRESS_VERSION: 2.3.0
+  DISTRIBUTION: alpine
 
 jobs:
   docker:
@@ -28,8 +30,8 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           build-args: |
-            NGINX_INGRESS_VERSION=2.3.0
-            CONTAINER_BASE=alpine
+            NGINX_INGRESS_VERSION=${{ env.UPSTREAM_NGINX_INGRESS_VERSION }}
+            CONTAINER_BASE=${{ env.DISTRIBUTION }}
           context: .
           file: Dockerbuild.nginxinc
           push: true

--- a/.github/workflows/manual-nginxinc.yml
+++ b/.github/workflows/manual-nginxinc.yml
@@ -36,7 +36,7 @@ jobs:
           build-args: |
             NGINX_INGRESS_VERSION=${{ env.UPSTREAM_NGINX_INGRESS_VERSION }}
             CONTAINER_BASE=${{ env.DISTRIBUTION }}
-          push: true
+          push: ${{ !env.ACT }}
           tags: >-
             ${{ env.DOCKERHUB_IMAGE }}:${{ env.UPSTREAM_NGINX_INGRESS_VERSION }},${{ env.DOCKERHUB_IMAGE}}:latest,
 


### PR DESCRIPTION
- Refactors the old job to run using the GitHub actions build and deploy: https://github.com/marketplace/actions/build-and-push-docker-images

Makes it a bit easier for readability and defining contexts, conditions (such as not running when building in ACT, so we can test build failures properly).

```
act -s DOCKERHUB_USERNAME=xxxx -s DOCKERHUB_API_TOKEN=xxx -W .github/workflows/manual-nginxinc.yml 
```
```
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Exec.exec: docker image inspect tonistiigi/binfmt:latest
| [command]/usr/bin/docker image inspect tonistiigi/binfmt:latest
| [
|     {
|         "Id": "sha256:354472a378935adfe74a19600b89bd9ada7bb058306fff23b3d6613405852faf",
|         "RepoTags": [
|             "tonistiigi/binfmt:latest"
|         ],
|         "RepoDigests": [
|             "tonistiigi/binfmt@sha256:66e11bea77a5ea9d6f0fe79b57cd2b189b5d15b93a2bdb925be22949232e4e55"
|         ],
|         "Parent": "",
|         "Comment": "buildkit.dockerfile.v0",
|         "Created": "2022-08-02T19:13:20.178433831Z",
|         "Container": "",
|         "ContainerConfig": {
|             "Hostname": "",
|             "Domainname": "",
|             "User": "",
|             "AttachStdin": false,
|             "AttachStdout": false,
|             "AttachStderr": false,
|             "Tty": false,
|             "OpenStdin": false,
|             "StdinOnce": false,
|             "Env": null,
|             "Cmd": null,
|             "Image": "",
|             "Volumes": null,
|             "WorkingDir": "",
|             "Entrypoint": null,
|             "OnBuild": null,
|             "Labels": null
|         },
|         "DockerVersion": "",
|         "Author": "",
|         "Config": {
|             "Hostname": "",
|             "Domainname": "",
|             "User": "",
|             "AttachStdin": false,
|             "AttachStdout": false,
|             "AttachStderr": false,
|             "Tty": false,
|             "OpenStdin": false,
|             "StdinOnce": false,
|             "Env": [
|                 "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
|                 "QEMU_PRESERVE_ARGV0=1"
|             ],
|             "Cmd": null,
|             "Image": "",
|             "Volumes": {
|                 "/tmp": {}
|             },
|             "WorkingDir": "/",
|             "Entrypoint": [
|                 "/usr/bin/binfmt"
|             ],
|             "OnBuild": null,
|             "Labels": {
|                 "org.opencontainers.image.created": "2022-08-02T18:32:39.936Z",
|                 "org.opencontainers.image.description": "Cross-platform emulator collection distributed with Docker images",
|                 "org.opencontainers.image.licenses": "MIT",
|                 "org.opencontainers.image.revision": "a161c41c7aeaf3ef1c5b97f91aa02a12cca73432",
|                 "org.opencontainers.image.source": "https://github.com/tonistiigi/binfmt",
|                 "org.opencontainers.image.title": "Binfmt",
|                 "org.opencontainers.image.url": "https://github.com/tonistiigi/binfmt",
|                 "org.opencontainers.image.version": "qemu-v7.0.0-28"
|             }
|         },
|         "Architecture": "amd64",
|         "Os": "linux",
|         "Size": 60182964,
|         "VirtualSize": 60182964,
|         "GraphDriver": {
|             "Data": {
|                 "LowerDir": "/var/lib/docker/overlay2/4b0100c69706eb0df25b1875ac359bf73b64ff59ba06ca8144b8b9bf9d073636/diff",
|                 "MergedDir": "/var/lib/docker/overlay2/76bb5edc65dab0c41e53b063365b9426faa198cca268ef548c20b000552f06c1/merged",
|                 "UpperDir": "/var/lib/docker/overlay2/76bb5edc65dab0c41e53b063365b9426faa198cca268ef548c20b000552f06c1/diff",
|                 "WorkDir": "/var/lib/docker/overlay2/76bb5edc65dab0c41e53b063365b9426faa198cca268ef548c20b000552f06c1/work"
|             },
|             "Name": "overlay2"
|         },
|         "RootFS": {
|             "Type": "layers",
|             "Layers": [
|                 "sha256:4c67e4044f8c0fe3e3efaf76f2a3d5d3d866f8ef2e8a9da756949d90e576baa0",
|                 "sha256:949acf1cb73a60306e050836deb85a26fe23e226f6bcc499872b057efbf22dd1"
|             ]
|         },
|         "Metadata": {
|             "LastTagTime": "0001-01-01T00:00:00Z"
|         }
|     }
| ]
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::endgroup::
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::group::Installing QEMU static binaries
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Exec.exec: docker run --rm --privileged tonistiigi/binfmt:latest --install all
| [command]/usr/bin/docker run --rm --privileged tonistiigi/binfmt:latest --install all
| {
|   "supported": [
|     "linux/amd64",
|     "linux/arm64",
|     "linux/riscv64",
|     "linux/ppc64le",
|     "linux/s390x",
|     "linux/386",
|     "linux/mips64le",
|     "linux/mips64",
|     "linux/arm/v7",
|     "linux/arm/v6"
|   ],
|   "emulators": [
|     "qemu-aarch64",
|     "qemu-arm",
|     "qemu-mips64",
|     "qemu-mips64el",
|     "qemu-ppc64le",
|     "qemu-riscv64",
|     "qemu-s390x"
|   ]
| }
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::endgroup::
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::group::Extracting available platforms
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Exec.getExecOutput: docker run --rm --privileged tonistiigi/binfmt:latest
| linux/amd64,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::endgroup::
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ✅  Success - Main Set up QEMU
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ⚙  ::set-output:: platforms=linux/amd64,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub] ⭐ Run Main Set up Docker Buildx
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   🐳  docker cp src=/home/ntyze/.cache/act/docker-setup-buildx-action@v2/ dst=/var/run/act/actions/docker-setup-buildx-action@v2/
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   🐳  docker exec cmd=[node /var/run/act/actions/docker-setup-buildx-action@v2/dist/index.js] user= workdir=
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Docker.isAvailable ok: /usr/bin/docker
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.isStandalone: false
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::group::Docker info
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Exec.exec: docker version
| [command]/usr/bin/docker version
| Client:
|  Version:           20.10.25+azure-1
|  API version:       1.41
|  Go version:        go1.19.9
|  Git commit:        b82b9f3a0e763304a250531cb9350aa6d93723c9
|  Built:             Thu Apr  6 10:55:17 UTC 2023
|  OS/Arch:           linux/amd64
|  Context:           default
|  Experimental:      true
| 
| Server: Docker Engine - Community
|  Engine:
|   Version:          24.0.2
|   API version:      1.43 (minimum version 1.12)
|   Go version:       go1.20.4
|   Git commit:       659604f
|   Built:            Thu May 25 21:51:00 2023
|   OS/Arch:          linux/amd64
|   Experimental:     false
|  containerd:
|   Version:          1.6.21
|   GitCommit:        3dce8eb055cbb6872793272b4f20ed16117344f8
|  runc:
|   Version:          1.1.7
|   GitCommit:        v1.1.7-0-g860f061
|  docker-init:
|   Version:          0.19.0
|   GitCommit:        de40ad0
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Exec.exec: docker info
| [command]/usr/bin/docker info
| Client:
|  Context:    default
|  Debug Mode: false
|  Plugins:
|   buildx: Docker Buildx (Docker Inc., 0.10.4+azure-1)
|   compose: Docker Compose (Docker Inc., 2.18.0+azure-1)
| 
| Server:
|  Containers: 32
|   Running: 1
|   Paused: 0
|   Stopped: 31
|  Images: 19
|  Server Version: 24.0.2
|  Storage Driver: overlay2
|   Backing Filesystem: extfs
|   Supports d_type: true
|   Using metacopy: false
|   Native Overlay Diff: true
|   userxattr: false
|  Logging Driver: json-file
|  Cgroup Driver: systemd
|  Cgroup Version: 2
|  Plugins:
|   Volume: local
|   Network: bridge host ipvlan macvlan null overlay
|   Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
|  Swarm: inactive
|  Runtimes: io.containerd.runc.v2 runc
|  Default Runtime: runc
|  Init Binary: docker-init
|  containerd version: 3dce8eb055cbb6872793272b4f20ed16117344f8
|  runc version: v1.1.7-0-g860f061
|  init version: de40ad0
|  Security Options:
|   apparmor
|   seccomp
|    Profile: builtin
|   cgroupns
|  Kernel Version: 6.2.6-76060206-generic
|  Operating System: Pop!_OS 22.04 LTS
|  OSType: linux
|  Architecture: x86_64
|  CPUs: 12
|  Total Memory: 31.09GiB
|  Name: pop-os
|  ID: 6a14b5d1-6f5a-4dd0-a259-29aa5dce1d8a
|  Docker Root Dir: /var/lib/docker
|  Debug Mode: false
|  Registry: https://index.docker.io/v1/
|  Labels:
|  Experimental: false
|  Insecure Registries:
|   127.0.0.0/8
|  Live Restore Enabled: false
| 
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::endgroup::
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Docker.isAvailable ok: /usr/bin/docker
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.isStandalone: false
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Exec.getExecOutput: docker buildx
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.isAvailable: true
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::group::Buildx version
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Docker.isAvailable ok: /usr/bin/docker
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.isStandalone: false
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Exec.exec: docker buildx version
| [command]/usr/bin/docker buildx version
| github.com/docker/buildx 0.10.4+azure-1 c513d34049e499c53468deac6c4267ee72948f02
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::endgroup::
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::group::Creating a new builder instance
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Docker.isAvailable ok: /usr/bin/docker
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.isStandalone: false
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Exec.getExecOutput: docker buildx version
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.versionSatisfies 0.10.4 statisfies >=0.3.0: true
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Docker.isAvailable ok: /usr/bin/docker
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.isStandalone: false
| [command]/usr/bin/docker buildx create --name builder-0b9aa039-2945-4bca-8334-eec85181adbc --driver docker-container --buildkitd-flags --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host --use
| builder-0b9aa039-2945-4bca-8334-eec85181adbc
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::endgroup::
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::group::Booting builder
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.versionSatisfies 0.10.4 statisfies >=0.4.0: true
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Docker.isAvailable ok: /usr/bin/docker
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.isStandalone: false
| [command]/usr/bin/docker buildx inspect --bootstrap --builder builder-0b9aa039-2945-4bca-8334-eec85181adbc
| #1 [internal] booting buildkit
| #1 pulling image moby/buildkit:buildx-stable-1
| #1 pulling image moby/buildkit:buildx-stable-1 1.1s done
| #1 creating container buildx_buildkit_builder-0b9aa039-2945-4bca-8334-eec85181adbc0
| #1 creating container buildx_buildkit_builder-0b9aa039-2945-4bca-8334-eec85181adbc0 0.4s done
| #1 DONE 1.4s
| Name:          builder-0b9aa039-2945-4bca-8334-eec85181adbc
| Driver:        docker-container
| Last Activity: 2023-06-22 12:41:11 +0000 UTC
| 
| Nodes:
| Name:      builder-0b9aa039-2945-4bca-8334-eec85181adbc0
| Endpoint:  unix:///var/run/docker.sock
| Status:    running
| Flags:     --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
| Buildkit:  v0.11.6
| Platforms: linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::endgroup::
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Docker.isAvailable ok: /usr/bin/docker
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.isStandalone: false
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Exec.getExecOutput: docker buildx inspect builder-0b9aa039-2945-4bca-8334-eec85181adbc
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::group::Inspect builder
| {
|   "nodes": [
|     {
|       "name": "builder-0b9aa039-2945-4bca-8334-eec85181adbc0",
|       "endpoint": "unix:///var/run/docker.sock",
|       "status": "running",
|       "buildkitd-flags": "--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host",
|       "buildkit": "v0.11.6",
|       "platforms": "linux/amd64,linux/amd64/v2,linux/amd64/v3,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6"
|     }
|   ],
|   "name": "builder-0b9aa039-2945-4bca-8334-eec85181adbc",
|   "driver": "docker-container",
|   "lastActivity": "2023-06-22T12:41:11.000Z"
| }
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::endgroup::
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::group::BuildKit version
| builder-0b9aa039-2945-4bca-8334-eec85181adbc0: v0.11.6
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::endgroup::
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ✅  Success - Main Set up Docker Buildx
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ⚙  ::set-output:: flags=--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ⚙  ::set-output:: name=builder-0b9aa039-2945-4bca-8334-eec85181adbc
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ⚙  ::set-output:: driver=docker-container
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ⚙  ::set-output:: platforms=linux/amd64,linux/amd64/v2,linux/amd64/v3,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ⚙  ::set-output:: nodes=[
  {
    "name": "builder-0b9aa039-2945-4bca-8334-eec85181adbc0",
    "endpoint": "unix:///var/run/docker.sock",
    "status": "running",
    "buildkitd-flags": "--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host",
    "buildkit": "v0.11.6",
    "platforms": "linux/amd64,linux/amd64/v2,linux/amd64/v3,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6"
  }
]
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ⚙  ::set-output:: endpoint=unix:///var/run/docker.sock
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ⚙  ::set-output:: status=running
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub] ⭐ Run Main Login to Docker Hub
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   🐳  docker cp src=/home/ntyze/.cache/act/docker-login-action@v2/ dst=/var/run/act/actions/docker-login-action@v2/
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   🐳  docker exec cmd=[node /var/run/act/actions/docker-login-action@v2/dist/index.js] user= workdir=
| Logging into Docker Hub...
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Exec.getExecOutput: docker login --password-stdin --username *** 
| Login Succeeded!
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ✅  Success - Main Login to Docker Hub
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub] ⭐ Run Main Build and push
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   🐳  docker cp src=/home/ntyze/.cache/act/docker-build-push-action@v4/ dst=/var/run/act/actions/docker-build-push-action@v4/
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   🐳  docker exec cmd=[node /var/run/act/actions/docker-build-push-action@v4/dist/index.js] user= workdir=
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::group::GitHub Actions runtime token ACs
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   🚧  ::warning::ACTIONS_RUNTIME_TOKEN not set
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::endgroup::
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::group::Docker info
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Exec.exec: docker version
| [command]/usr/bin/docker version
| Client:
|  Version:           20.10.25+azure-1
|  API version:       1.41
|  Go version:        go1.19.9
|  Git commit:        b82b9f3a0e763304a250531cb9350aa6d93723c9
|  Built:             Thu Apr  6 10:55:17 UTC 2023
|  OS/Arch:           linux/amd64
|  Context:           default
|  Experimental:      true
| 
| Server: Docker Engine - Community
|  Engine:
|   Version:          24.0.2
|   API version:      1.43 (minimum version 1.12)
|   Go version:       go1.20.4
|   Git commit:       659604f
|   Built:            Thu May 25 21:51:00 2023
|   OS/Arch:          linux/amd64
|   Experimental:     false
|  containerd:
|   Version:          1.6.21
|   GitCommit:        3dce8eb055cbb6872793272b4f20ed16117344f8
|  runc:
|   Version:          1.1.7
|   GitCommit:        v1.1.7-0-g860f061
|  docker-init:
|   Version:          0.19.0
|   GitCommit:        de40ad0
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Exec.exec: docker info
| [command]/usr/bin/docker info
| Client:
|  Context:    default
|  Debug Mode: false
|  Plugins:
|   buildx: Docker Buildx (Docker Inc., 0.10.4+azure-1)
|   compose: Docker Compose (Docker Inc., 2.18.0+azure-1)
| 
| Server:
|  Containers: 33
|   Running: 2
|   Paused: 0
|   Stopped: 31
|  Images: 19
|  Server Version: 24.0.2
|  Storage Driver: overlay2
|   Backing Filesystem: extfs
|   Supports d_type: true
|   Using metacopy: false
|   Native Overlay Diff: true
|   userxattr: false
|  Logging Driver: json-file
|  Cgroup Driver: systemd
|  Cgroup Version: 2
|  Plugins:
|   Volume: local
|   Network: bridge host ipvlan macvlan null overlay
|   Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
|  Swarm: inactive
|  Runtimes: runc io.containerd.runc.v2
|  Default Runtime: runc
|  Init Binary: docker-init
|  containerd version: 3dce8eb055cbb6872793272b4f20ed16117344f8
|  runc version: v1.1.7-0-g860f061
|  init version: de40ad0
|  Security Options:
|   apparmor
|   seccomp
|    Profile: builtin
|   cgroupns
|  Kernel Version: 6.2.6-76060206-generic
|  Operating System: Pop!_OS 22.04 LTS
|  OSType: linux
|  Architecture: x86_64
|  CPUs: 12
|  Total Memory: 31.09GiB
|  Name: pop-os
|  ID: 6a14b5d1-6f5a-4dd0-a259-29aa5dce1d8a
|  Docker Root Dir: /var/lib/docker
|  Debug Mode: false
|  Username: ***
|  Registry: https://index.docker.io/v1/
|  Labels:
|  Experimental: false
|  Insecure Registries:
|   127.0.0.0/8
|  Live Restore Enabled: false
| 
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::endgroup::
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Docker.isAvailable ok: /usr/bin/docker
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.isStandalone: false
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Exec.getExecOutput: docker buildx
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.isAvailable: true
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::group::Buildx version
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Docker.isAvailable ok: /usr/bin/docker
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.isStandalone: false
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Exec.exec: docker buildx version
| [command]/usr/bin/docker buildx version
| github.com/docker/buildx 0.10.4+azure-1 c513d34049e499c53468deac6c4267ee72948f02
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::endgroup::
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Docker.isAvailable ok: /usr/bin/docker
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.isStandalone: false
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Exec.getExecOutput: docker buildx version
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.versionSatisfies 0.10.4 statisfies >=0.10.0: true
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.versionSatisfies 0.10.4 statisfies >=0.8.0: true
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.versionSatisfies 0.10.4 statisfies >=0.10.0: true
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Docker.isAvailable ok: /usr/bin/docker
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.isStandalone: false
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Exec.getExecOutput: docker buildx inspect 
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::BuildKit.versionSatisfies v0.11.6: >=0.11.0
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::BuildKit.versionSatisfies builder-0b9aa039-2945-4bca-8334-eec85181adbc0: version v0.11.6
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.versionSatisfies 0.10.4 statisfies >=0.6.0: true
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Docker.isAvailable ok: /usr/bin/docker
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.isStandalone: false
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Exec.getExecOutput: docker buildx build --build-arg NGINX_INGRESS_VERSION=2.3.0 --build-arg CONTAINER_BASE=alpine --cache-from type=gha --cache-to type=gha,mode=max --file Dockerfile.nginxinc --iidfile /tmp/docker-actions-toolkit-K4NcWT/iidfile --provenance mode=max,builder-id=https://github.com/signalsciences/sigsci-nginx-ingress-controller/actions/runs/1 --tag signalsciences/sigsci-nginxinc-ingress-controller:2.3.0 --tag signalsciences/sigsci-nginxinc-ingress-controller:latest --metadata-file /tmp/docker-actions-toolkit-K4NcWT/metadata-file .
| [command]/usr/bin/docker buildx build --build-arg NGINX_INGRESS_VERSION=2.3.0 --build-arg CONTAINER_BASE=alpine --cache-from type=gha --cache-to type=gha,mode=max --file Dockerfile.nginxinc --iidfile /tmp/docker-actions-toolkit-K4NcWT/iidfile --provenance mode=max,builder-id=https://github.com/signalsciences/sigsci-nginx-ingress-controller/actions/runs/1 --tag signalsciences/sigsci-nginxinc-ingress-controller:2.3.0 --tag signalsciences/sigsci-nginxinc-ingress-controller:latest --metadata-file /tmp/docker-actions-toolkit-K4NcWT/metadata-file .
| WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
| #1 [internal] load build definition from Dockerfile.nginxinc
| #1 transferring dockerfile: 1.72kB done
| #1 DONE 0.0s
| 
| #2 [internal] load .dockerignore
| #2 transferring context: 2B done
| #2 DONE 0.0s
| 
| #3 [internal] load metadata for docker.io/nginx/nginx-ingress:2.3.0-alpine
| #3 ...
| 
| #4 [auth] nginx/nginx-ingress:pull token for registry-1.docker.io
| #4 DONE 0.0s
| 
| #3 [internal] load metadata for docker.io/nginx/nginx-ingress:2.3.0-alpine
| #3 DONE 1.4s
| 
| #5 [1/2] FROM docker.io/nginx/nginx-ingress:2.3.0-alpine@sha256:515e2b9f0cd15701991701cbeb19b5869de0a3844469f4b137341ec37a1926b3
| #5 resolve docker.io/nginx/nginx-ingress:2.3.0-alpine@sha256:515e2b9f0cd15701991701cbeb19b5869de0a3844469f4b137341ec37a1926b3 done
| #5 sha256:a881f34c01817ff10d7b10546950f53d25948ced32f4bf3d4aaf13ec0896cdb2 0B / 13.61MB 0.2s
| #5 sha256:f50b5bbd9573c48b7d91db409e16bf96cbacdb1da020aa9ecb4e16191120c735 0B / 1.13MB 0.2s
| #5 sha256:a881f34c01817ff10d7b10546950f53d25948ced32f4bf3d4aaf13ec0896cdb2 1.05MB / 13.61MB 0.3s
| #5 sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 0B / 32B 0.2s
| #5 sha256:a752bffe166e3a8d21270dd76e9820cc16430ae9425fc279928e84400d049406 0B / 7.28MB 0.2s
| #5 sha256:a881f34c01817ff10d7b10546950f53d25948ced32f4bf3d4aaf13ec0896cdb2 13.61MB / 13.61MB 0.6s done
| #5 sha256:f50b5bbd9573c48b7d91db409e16bf96cbacdb1da020aa9ecb4e16191120c735 1.13MB / 1.13MB 0.6s done
| #5 sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 32B / 32B 0.6s done
| #5 sha256:a752bffe166e3a8d21270dd76e9820cc16430ae9425fc279928e84400d049406 7.28MB / 7.28MB 0.8s done
| #5 sha256:f3c5ffbedfb2b04855073e67368f62057671052390d94d74174dece1e8c5144d 1.39kB / 1.39kB 0.2s done
| #5 sha256:2b101aaad7024d10982d455bf1138b39fd1c0fb5f1460fa2350a16b231076afd 665B / 665B 0.2s done
| #5 sha256:0b3cca595de12677cd14cc43d1fcf9832bf1263e771b66ba782b06248ad15589 894B / 894B 0.2s done
| #5 sha256:29e4e820b7210a8dd7e779fa527ce217e4ed0514d31d30e6b35f601f65a16a2d 0B / 604B 0.2s
| #5 sha256:29e4e820b7210a8dd7e779fa527ce217e4ed0514d31d30e6b35f601f65a16a2d 604B / 604B 0.2s done
| #5 sha256:6a89def8063152acad33aa7eba1cd2d9c5388fa6fee6d3a6e7c8bed1ee0546aa 0B / 7.38MB 0.2s
| #5 sha256:530afca65e2ea04227630ae746e0c85b2bd1a179379cbf2b6501b49c4cab2ccc 2.80MB / 2.80MB 0.2s done
| #5 extracting sha256:530afca65e2ea04227630ae746e0c85b2bd1a179379cbf2b6501b49c4cab2ccc 0.0s done
| #5 sha256:6a89def8063152acad33aa7eba1cd2d9c5388fa6fee6d3a6e7c8bed1ee0546aa 1.05MB / 7.38MB 0.3s
| #5 sha256:6a89def8063152acad33aa7eba1cd2d9c5388fa6fee6d3a6e7c8bed1ee0546aa 7.38MB / 7.38MB 0.4s done
| #5 extracting sha256:6a89def8063152acad33aa7eba1cd2d9c5388fa6fee6d3a6e7c8bed1ee0546aa
| #5 extracting sha256:6a89def8063152acad33aa7eba1cd2d9c5388fa6fee6d3a6e7c8bed1ee0546aa 0.2s done
| #5 extracting sha256:29e4e820b7210a8dd7e779fa527ce217e4ed0514d31d30e6b35f601f65a16a2d done
| #5 extracting sha256:0b3cca595de12677cd14cc43d1fcf9832bf1263e771b66ba782b06248ad15589 done
| #5 extracting sha256:2b101aaad7024d10982d455bf1138b39fd1c0fb5f1460fa2350a16b231076afd done
| #5 extracting sha256:f3c5ffbedfb2b04855073e67368f62057671052390d94d74174dece1e8c5144d done
| #5 DONE 1.5s
| 
| #5 [1/2] FROM docker.io/nginx/nginx-ingress:2.3.0-alpine@sha256:515e2b9f0cd15701991701cbeb19b5869de0a3844469f4b137341ec37a1926b3
| #5 extracting sha256:a752bffe166e3a8d21270dd76e9820cc16430ae9425fc279928e84400d049406 0.1s done
| #5 extracting sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 done
| #5 extracting sha256:f50b5bbd9573c48b7d91db409e16bf96cbacdb1da020aa9ecb4e16191120c735
| #5 extracting sha256:f50b5bbd9573c48b7d91db409e16bf96cbacdb1da020aa9ecb4e16191120c735 0.0s done
| #5 extracting sha256:a881f34c01817ff10d7b10546950f53d25948ced32f4bf3d4aaf13ec0896cdb2
| #5 extracting sha256:a881f34c01817ff10d7b10546950f53d25948ced32f4bf3d4aaf13ec0896cdb2 0.2s done
| #5 DONE 1.8s
| 
| #6 [2/2] RUN apk update && apk add --no-cache gnupg wget --virtual ./build_deps     && ALPINE_RELEASE=$(cat /etc/alpine-release)     && ALPINE_RELEASE=${ALPINE_RELEASE::-2}     && NGXVERSION=$(nginx -v 2>&1 | sed 's%^[^/]*/\([0-9]*\.[0-9]*\.[0-9]*\).*%\1%')     && MODULE_VERSION=$(wget -O- -q https://dl.signalsciences.net/sigsci-module-nginx-native/VERSION)     && wget https://apk.signalsciences.net/sigsci_apk.pub && mv sigsci_apk.pub /etc/apk/keys     && echo "https://apk.signalsciences.net/${ALPINE_RELEASE}/main" | tee -a /etc/apk/repositories     && apk add ${PKGNAME}-${NGXVERSION}     && sed -i 's@^pid.*@&\nload_module /usr/lib/nginx/modules/ngx_http_sigsci_module.so;\n@' /etc/nginx/nginx.conf     && apk del --no-cache ./build_deps     && rm /etc/apk/keys/sigsci_apk.pub
| #0 0.093 fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
| #6 0.340 fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
| #6 0.578 v3.16.6-17-g2a3c4b0b53d [https://dl-cdn.alpinelinux.org/alpine/v3.16/main]
| #6 0.578 v3.16.6-14-ga282003cf14 [https://dl-cdn.alpinelinux.org/alpine/v3.16/community]
| #6 0.578 OK: 17061 distinct packages available
| #6 0.610 fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
| #6 0.818 fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
| #6 1.020 (1/28) Installing libassuan (2.5.6-r0)
| #6 1.047 (2/28) Installing pinentry (1.2.0-r0)
| #6 1.073 Executing pinentry-1.2.0-r0.post-install
| #6 1.075 (3/28) Installing gnupg-gpgconf (2.2.35-r4)
| #6 1.102 (4/28) Installing sqlite-libs (3.40.1-r0)
| #6 1.133 (5/28) Installing gpg (2.2.35-r4)
| #6 1.166 (6/28) Installing npth (1.6-r1)
| #6 1.195 (7/28) Installing gpg-agent (2.2.35-r4)
| #6 1.229 (8/28) Installing gpg-wks-server (2.2.35-r4)
| #6 1.256 (9/28) Installing libksba (1.6.4-r0)
| #6 1.281 (10/28) Installing gpgsm (2.2.35-r4)
| #6 1.310 (11/28) Installing gpgv (2.2.35-r4)
| #6 1.333 (12/28) Installing gmp (6.2.1-r2)
| #6 1.363 (13/28) Installing nettle (3.7.3-r0)
| #6 1.403 (14/28) Installing libffi (3.4.2-r1)
| #6 1.425 (15/28) Installing p11-kit (0.24.1-r0)
| #6 1.452 (16/28) Installing libtasn1 (4.18.0-r1)
| #6 1.475 (17/28) Installing libunistring (1.0-r0)
| #6 1.510 (18/28) Installing gnutls (3.7.7-r1)
| #6 1.544 (19/28) Installing gdbm (1.23-r0)
| #6 1.577 (20/28) Installing libsasl (2.1.28-r1)
| #6 1.605 (21/28) Installing libldap (2.6.3-r3)
| #6 1.636 (22/28) Installing gnupg-dirmngr (2.2.35-r4)
| #6 1.667 (23/28) Installing gnupg-utils (2.2.35-r4)
| #6 1.693 (24/28) Installing gnupg-wks-client (2.2.35-r4)
| #6 1.721 (25/28) Installing gnupg (2.2.35-r4)
| #6 1.744 (26/28) Installing libidn2 (2.3.2-r2)
| #6 1.770 (27/28) Installing wget (1.21.3-r0)
| #6 1.796 (28/28) Installing ./build_deps (20230622.124119)
| #6 1.796 Executing busybox-1.35.0-r15.trigger
| #6 1.799 OK: 40 MiB in 73 packages
| #6 1.956 --2023-06-22 12:41:20--  https://apk.signalsciences.net/sigsci_apk.pub
| #6 1.964 Resolving apk.signalsciences.net (apk.signalsciences.net)... 52.84.90.69, 52.84.90.121, 52.84.90.76, ...
| #6 2.005 Connecting to apk.signalsciences.net (apk.signalsciences.net)|52.84.90.69|:443... connected.
| #6 2.046 HTTP request sent, awaiting response... 200 OK
| #6 2.086 Length: 451 [application/x-mspublisher]
| #6 2.086 Saving to: 'sigsci_apk.pub'
| #6 2.086 
| #6 2.086      0K                                                       100% 14.2M=0s
| #6 2.086 
| #6 2.086 2023-06-22 12:41:20 (14.2 MB/s) - 'sigsci_apk.pub' saved [451/451]
| #6 2.086 
| #6 2.093 https://apk.signalsciences.net/3.16/main
| #6 2.202 fetch https://apk.signalsciences.net/3.16/main/x86_64/APKINDEX.tar.gz
| #6 2.396 (1/1) Installing nginx-module-sigsci-nxo-1.23.0 (1.1.7-r0)
| #6 2.954 Executing nginx-module-sigsci-nxo-1.23.0-1.1.7-r0.post-install
| #6 2.956 Using /usr/sbin/nginx 1.23.0 to link modules
| #6 2.956 Found nginx modules in /usr/lib/nginx/modules. Linking to version 1.23.0
| #6 2.957 Have nginx-plus module dir /etc/nginx/modules. Ensure links to version 1.23.0
| #6 2.957 Have /usr/share/nginx so prepare libs:
| #6 2.957 Set links in /usr/share/nginx/modules:
| #6 2.958 total 0
| #6 2.958 lrwxrwxrwx    1 root     root            52 Jun 22 12:41 ndk_http_module.so -> /usr/lib/nginx/modules/ndk_http_nxo_module-1.23.0.so
| #6 2.958 lrwxrwxrwx    1 root     root            59 Jun 22 12:41 ngx_http_sigsci_module.so -> /usr/lib/nginx/modules/ngx_http_sigsci_nxo_module-1.23.0.so
| #6 2.959 OK: 40 MiB in 74 packages
| #6 2.995 fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
| #6 3.175 fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
| #6 3.283 fetch https://apk.signalsciences.net/3.16/main/x86_64/APKINDEX.tar.gz
| #6 3.449 (1/28) Purging ./build_deps (20230622.124119)
| #6 3.449 (2/28) Purging gnupg (2.2.35-r4)
| #6 3.449 (3/28) Purging gpg-wks-server (2.2.35-r4)
| #6 3.449 (4/28) Purging gpgsm (2.2.35-r4)
| #6 3.449 (5/28) Purging gpgv (2.2.35-r4)
| #6 3.449 (6/28) Purging gnupg-utils (2.2.35-r4)
| #6 3.449 (7/28) Purging gnupg-wks-client (2.2.35-r4)
| #6 3.449 (8/28) Purging gpg (2.2.35-r4)
| #6 3.450 (9/28) Purging gpg-agent (2.2.35-r4)
| #6 3.450 (10/28) Purging gnupg-dirmngr (2.2.35-r4)
| #6 3.450 (11/28) Purging gnupg-gpgconf (2.2.35-r4)
| #6 3.450 (12/28) Purging pinentry (1.2.0-r0)
| #6 3.450 (13/28) Purging wget (1.21.3-r0)
| #6 3.450 (14/28) Purging libassuan (2.5.6-r0)
| #6 3.450 (15/28) Purging sqlite-libs (3.40.1-r0)
| #6 3.450 (16/28) Purging npth (1.6-r1)
| #6 3.450 (17/28) Purging libksba (1.6.4-r0)
| #6 3.450 (18/28) Purging gnutls (3.7.7-r1)
| #6 3.451 (19/28) Purging nettle (3.7.3-r0)
| #6 3.451 (20/28) Purging gmp (6.2.1-r2)
| #6 3.451 (21/28) Purging p11-kit (0.24.1-r0)
| #6 3.451 (22/28) Purging libffi (3.4.2-r1)
| #6 3.451 (23/28) Purging libtasn1 (4.18.0-r1)
| #6 3.451 (24/28) Purging libidn2 (2.3.2-r2)
| #6 3.451 (25/28) Purging libunistring (1.0-r0)
| #6 3.451 (26/28) Purging libldap (2.6.3-r3)
| #6 3.451 (27/28) Purging libsasl (2.1.28-r1)
| #6 3.452 (28/28) Purging gdbm (1.23-r0)
| #6 3.452 Executing busybox-1.35.0-r15.trigger
| #6 3.455 OK: 28 MiB in 46 packages
| #6 DONE 3.6s
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::group::Metadata
| {
|   "containerimage.buildinfo": {
|     "frontend": "dockerfile.v0",
|     "attrs": {
|       "build-arg:CONTAINER_BASE": "alpine",
|       "build-arg:NGINX_INGRESS_VERSION": "2.3.0",
|       "filename": "Dockerfile.nginxinc",
|       "vcs:revision": "fa79a933be10f1c78faf7eadffc561af09bb1f7c",
|       "vcs:source": "https://github.com/signalsciences/sigsci-nginx-ingress-controller.git"
|     },
|     "sources": [
|       {
|         "type": "docker-image",
|         "ref": "docker.io/nginx/nginx-ingress:2.3.0-alpine",
|         "pin": "sha256:515e2b9f0cd15701991701cbeb19b5869de0a3844469f4b137341ec37a1926b3"
|       }
|     ]
|   }
| }
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::endgroup::
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ✅  Success - Main Build and push
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ⚙  ::set-output:: metadata={
  "containerimage.buildinfo": {
    "frontend": "dockerfile.v0",
    "attrs": {
      "build-arg:CONTAINER_BASE": "alpine",
      "build-arg:NGINX_INGRESS_VERSION": "2.3.0",
      "filename": "Dockerfile.nginxinc",
      "vcs:revision": "fa79a933be10f1c78faf7eadffc561af09bb1f7c",
      "vcs:source": "https://github.com/signalsciences/sigsci-nginx-ingress-controller.git"
    },
    "sources": [
      {
        "type": "docker-image",
        "ref": "docker.io/nginx/nginx-ingress:2.3.0-alpine",
        "pin": "sha256:515e2b9f0cd15701991701cbeb19b5869de0a3844469f4b137341ec37a1926b3"
      }
    ]
  }
}
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub] ⭐ Run Main Echo output
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/5] user= workdir=
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ⚙  ::set-output:: image=signalsciences/sigsci-nginxinc-ingress-controller:latest,signalsciences/sigsci-nginxinc-ingress-controller:2.3.0
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ✅  Success - Main Echo output
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub] ⭐ Run Post Build and push
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   🐳  docker exec cmd=[node /var/run/act/actions/docker-build-push-action@v4/dist/index.js] user= workdir=
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::group::Removing temp folder /tmp/docker-actions-toolkit-K4NcWT
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::endgroup::
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ✅  Success - Post Build and push
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub] ⭐ Run Post Login to Docker Hub
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   🐳  docker exec cmd=[node /var/run/act/actions/docker-login-action@v2/dist/index.js] user= workdir=
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Exec.getExecOutput: docker logout 
| [command]/usr/bin/docker logout 
| Removing login credentials for https://index.docker.io/v1/
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ✅  Success - Post Login to Docker Hub
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub] ⭐ Run Post Set up Docker Buildx
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   🐳  docker exec cmd=[node /var/run/act/actions/docker-setup-buildx-action@v2/dist/index.js] user= workdir=
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::group::Removing builder
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.isStandalone: false
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Exec.getExecOutput: docker buildx inspect builder-0b9aa039-2945-4bca-8334-eec85181adbc
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Builder.exists: true
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   💬  ::debug::Buildx.isStandalone: false
| [command]/usr/bin/docker buildx rm builder-0b9aa039-2945-4bca-8334-eec85181adbc
| builder-0b9aa039-2945-4bca-8334-eec85181adbc removed
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::endgroup::
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::group::Cleaning up certificates
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ❓  ::endgroup::
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub]   ✅  Success - Post Set up Docker Buildx
[Manual Push NginxInc Image to DockerHub/buildpush_to_dockerhub] 🏁  Job succeeded
```