### PR TITLE
Fix ARM64 builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 ARG NGINX_INGRESS_VERSION=${NGINX_INGRESS_VERSION:-v1.10.0}
-FROM --platform=$BUILDPLATFORM registry.k8s.io/ingress-nginx/controller:${NGINX_INGRESS_VERSION}
+FROM registry.k8s.io/ingress-nginx/controller:${NGINX_INGRESS_VERSION}
 
-ARG BUILDPLATFORM
 ARG PKGNAME=${PKGNAME:-nginx-module-sigsci-nxo}
 
 # Change to the root user to update the container


### PR DESCRIPTION
Fixes #67

Currently we have a multi arch builder in our Github actions build action:

```
docker buildx create --name build_multiarch --use
docker buildx build --platform linux/amd64,linux/arm64 --build-arg  NGINX_INGRESS_VERSION=v${TAG} --tag ${REPO}:${TAG} --tag ${REPO}:latest --push .
```

However the Dockerfile is using:
```
FROM --platform=$BUILDPLATFORM registry.k8s.io/ingress-nginx/controller:${NGINX_INGRESS_VERSION}
```

This is problematic due to the fact `BUILDPLATFORM` is a variable that always matches the platform of the current machine.  (e.g. `linux/amd64`). So during build, this would be consistently overriding the platform in the FROM directive.[ This is visible in the actions runs.](https://github.com/signalsciences/sigsci-nginx-ingress-controller/actions/runs/8817048997/job/24202525423)

```
arch && sudo docker run -it --platform=linux/arm64 signalsciences/sigsci-nginx-ingress-controller:latest uname -a
arm64
Linux f3469fc89915 6.6.26-linuxkit #1 SMP Sat Apr 27 04:13:19 UTC 2024 x86_64 Linux
```

The inclusion of build platform is unnecessary in the build pipeline, and if one was to be used in the way it wanted to be, it would be TARGETPLATFORM, however buildx assumes this anyway.

Also not sure why we are setting ARG there either, so I've removed it. We will want to just do a manual re-run when this is merged. 