### PR TITLE
chore: build/deploy a 1.11.5 version

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -15,7 +15,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_API_TOKEN }}
       - name: Build and Push image to docker Hub
         env:
-          TAG: 1.12.1
+          TAG: 1.11.5
           REPO: signalsciences/sigsci-nginx-ingress-controller
         run: |
           docker buildx create --name build_multiarch --use


### PR DESCRIPTION
## What 
- Creates a `1.11.5` build

## Why
- [CVE-2025-1974](https://github.com/kubernetes/kubernetes/issues/131009) is patched in version `1.11.5`

## Linked Issue
https://github.com/signalsciences/sigsci-nginx-ingress-controller/issues/76

## Tested
I locally ran 
```bash
$ docker buildx build --platform linux/amd64,linux/arm64 --build-arg  NGINX_INGRESS_VERSION=v1.11.5 .
```
and was able to successfully build the images. 