### PR TITLE
Add platform to args for chainguard builds

### DIFF
--- a/.github/workflows/manual-chainguard.yml
+++ b/.github/workflows/manual-chainguard.yml
@@ -2,7 +2,7 @@ name: Manual Push Docker Hub Image (Chainguard Fork)
 
 on:
   pull_request: 
-    branches: [ "main", "add-linux-arm-support" ]
+    branches: [ "main", "jcocks/fix-arm64" ]
   workflow_dispatch:
     inputs:
       chainguard_tag:
@@ -65,12 +65,12 @@ jobs:
           
           # Build and push AMD64 base image
           make build ARCH=amd64
-          make image ARCH=amd64 REGISTRY=localhost:5000/local-chainguard-ingress TAG=${{ env.CHAINGUARD_TAG }}-amd64
+          make image ARCH=amd64 PLATFORM=linux/amd64 REGISTRY=localhost:5000/local-chainguard-ingress TAG=${{ env.CHAINGUARD_TAG }}-amd64
           docker push localhost:5000/local-chainguard-ingress/controller:${{ env.CHAINGUARD_TAG }}-amd64
 
           # Build and push ARM64 base image
           make build ARCH=arm64
-          make image ARCH=arm64 REGISTRY=localhost:5000/local-chainguard-ingress TAG=${{ env.CHAINGUARD_TAG }}-arm64
+          make image ARCH=arm64 PLATFORM=linux/arm64 REGISTRY=localhost:5000/local-chainguard-ingress TAG=${{ env.CHAINGUARD_TAG }}-arm64
           docker push localhost:5000/local-chainguard-ingress/controller:${{ env.CHAINGUARD_TAG }}-arm64
 
           # Create and push multi-arch manifest list in local registry

--- a/.github/workflows/manual-chainguard.yml
+++ b/.github/workflows/manual-chainguard.yml
@@ -2,7 +2,7 @@ name: Manual Push Docker Hub Image (Chainguard Fork)
 
 on:
   pull_request: 
-    branches: [ "main", "jcocks/fix-arm64" ]
+    branches: [ "main" ]
   workflow_dispatch:
     inputs:
       chainguard_tag:
@@ -78,7 +78,7 @@ jobs:
             localhost:5000/local-chainguard-ingress/controller:${{ env.CHAINGUARD_TAG }}-amd64 \
             localhost:5000/local-chainguard-ingress/controller:${{ env.CHAINGUARD_TAG }}-arm64
 
-          # Explicitly annotate platform architectures because local builds default to the host architecture metadata (amd64)
+          # Explicitly annotate platform architectures because local builds default to the $PLATFORM
           docker manifest annotate localhost:5000/local-chainguard-ingress/controller:${{ env.CHAINGUARD_TAG }} \
             localhost:5000/local-chainguard-ingress/controller:${{ env.CHAINGUARD_TAG }}-amd64 --os linux --arch amd64
           docker manifest annotate localhost:5000/local-chainguard-ingress/controller:${{ env.CHAINGUARD_TAG }} \

--- a/.github/workflows/manual-chainguard.yml
+++ b/.github/workflows/manual-chainguard.yml
@@ -78,7 +78,9 @@ jobs:
             localhost:5000/local-chainguard-ingress/controller:${{ env.CHAINGUARD_TAG }}-amd64 \
             localhost:5000/local-chainguard-ingress/controller:${{ env.CHAINGUARD_TAG }}-arm64
 
-          # Explicitly annotate platform architectures because local builds default to the $PLATFORM
+          # Annotate platform architectures explicitly. With --platform set on each build
+          # the images already carry correct metadata, so this is just a safety net to
+          # guarantee the manifest list entries are labelled correctly.
           docker manifest annotate localhost:5000/local-chainguard-ingress/controller:${{ env.CHAINGUARD_TAG }} \
             localhost:5000/local-chainguard-ingress/controller:${{ env.CHAINGUARD_TAG }}-amd64 --os linux --arch amd64
           docker manifest annotate localhost:5000/local-chainguard-ingress/controller:${{ env.CHAINGUARD_TAG }} \


### PR DESCRIPTION
The arm64 variant of signalsciences/sigsci-nginx-ingress-controller-chainguard crashes on startup with `exec /usr/bin/dumb-init: exec format error` reported via CSOC:
https://fastly.slack.com/archives/C01D8HGSXFD/p1784547136472969

What I found inside the published arm64 image is `nginx-ingress-controller` binary itself is aarch64 (cross-compiled Go binary):

```
/tmp/controller: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, stripped
```

but `/usr/bin/dumb-init` is x86-64 (the container entrypoint hence the crash).
```
/tmp/dumb-init:  ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), static-pie linked,
                    BuildID[sha1]=078525fac8769aa78d176914313e8ba802e6d320, stripped
```

The workflow builds the Chainguard base image on an amd64 runner with `make image ARCH=arm64`.
In the fork's Makefile, ARCH only sets `--build-arg TARGETARCH=arm64`, which just selects which directory (bin/arm64/) the go binaries are copied from.

The `--platform` flag is only added when PLATFORM is set and the workflow never set it. 
So `FROM ${BASE_IMAGE}` resolved registry.k8s.io/ingress-nginx/nginx to the host's architecture: `amd64` 
That base image supplies dumb-init, nginx, and the rest of the userland so that creates a bit of a frankenstein image with arm64 go binaries on top of an amd64 filesystem.

We need pass `PLATFORM=linux/amd64` and `PLATFORM=linux/arm64` to the make image calls so `docker build --platform` pulls the matching base layers. QEMU (already set up in the workflow) handles the emulated RUN apk steps during the arm64 build.

Once merged, you can verify via the following before deploying to dockerhub:
```
cid=$(docker create --platform linux/arm64 signalsciences/sigsci-nginx-ingress-controller-chainguard:latest /bin/true)
docker cp "$cid:/usr/bin/dumb-init" /tmp/di && file /tmp/di
docker rm "$cid"
```