### PR TITLE
Update Chainguard tag to v1.15.10, build with Go 1.26.6, remove ModSecurity

### DIFF
--- a/.github/workflows/manual-chainguard.yml
+++ b/.github/workflows/manual-chainguard.yml
@@ -8,7 +8,7 @@ on:
       chainguard_tag:
         description: 'Chainguard Ingress Tag'
         required: true
-        default: 'v1.15.7'
+        default: 'v1.15.10'
       module_tag:
         description: 'Fastly Module Tag'
         required: true
@@ -19,8 +19,13 @@ permissions:
 
 # Set up global environment variables with fallbacks for PR runs
 env:
-  CHAINGUARD_TAG: ${{ github.event.inputs.chainguard_tag || 'v1.15.6' }}
+  CHAINGUARD_TAG: ${{ github.event.inputs.chainguard_tag || 'v1.15.10' }}
   MODULE_TAG: ${{ github.event.inputs.module_tag || '1.4.0' }}
+  # The fork pins GOLANG_VERSION at 1.26.2, which carries 63 known stdlib CVEs
+  # and is the largest source of vulnerability reports against this image.
+  # Override the toolchain used to compile the controller; go.mod only requires
+  # go 1.26.1, so a newer patch release needs no source changes.
+  GO_VERSION: '1.26.6'
 
 jobs:
   deploy:
@@ -64,12 +69,15 @@ jobs:
           cd ingress-nginx-fork
           
           # Build and push AMD64 base image
-          make build ARCH=amd64
+          # TAG is baked into the binary as version.RELEASE. Without it the build
+          # falls back to the fork's TAG file, which it does not bump per release,
+          # so the controller reported v1.15.5 whatever image tag it shipped under.
+          make build ARCH=amd64 GO_VERSION=${{ env.GO_VERSION }} TAG=${{ env.CHAINGUARD_TAG }}
           make image ARCH=amd64 PLATFORM=linux/amd64 REGISTRY=localhost:5000/local-chainguard-ingress TAG=${{ env.CHAINGUARD_TAG }}-amd64
           docker push localhost:5000/local-chainguard-ingress/controller:${{ env.CHAINGUARD_TAG }}-amd64
 
           # Build and push ARM64 base image
-          make build ARCH=arm64
+          make build ARCH=arm64 GO_VERSION=${{ env.GO_VERSION }} TAG=${{ env.CHAINGUARD_TAG }}
           make image ARCH=arm64 PLATFORM=linux/arm64 REGISTRY=localhost:5000/local-chainguard-ingress TAG=${{ env.CHAINGUARD_TAG }}-arm64
           docker push localhost:5000/local-chainguard-ingress/controller:${{ env.CHAINGUARD_TAG }}-arm64
 

--- a/Dockerfile.chainguard
+++ b/Dockerfile.chainguard
@@ -2,7 +2,7 @@
 # Defaulting to a local tag, but this can be overridden during build
 # e.g., docker build --build-arg LOCAL_CHAINGUARD_IMAGE=my-local-chainguard-fork:v1.0 .
 # ARG LOCAL_CHAINGUARD_IMAGE=${LOCAL_CHAINGUARD_IMAGE:-localhost/chainguard-ingress-nginx-controller:latest}
-ARG LOCAL_CHAINGUARD_IMAGE=${LOCAL_CHAINGUARD_IMAGE:-local-chainguard-ingress/controller:v1.15.6}
+ARG LOCAL_CHAINGUARD_IMAGE=${LOCAL_CHAINGUARD_IMAGE:-local-chainguard-ingress/controller:v1.15.10}
 FROM ${LOCAL_CHAINGUARD_IMAGE}
 
 ARG PKGNAME=${PKGNAME:-nginx-module-sigsci-nxo}
@@ -31,6 +31,52 @@ RUN apk -U upgrade && apk add --no-cache gnupg wget curl --virtual ./build_deps 
     # cleanup
     && apk del --no-cache ./build_deps \
     && rm /etc/apk/keys/sigsci_apk.pub
+
+# Remove ModSecurity. It arrives pre-built in the NGINX base image that the
+# Chainguard fork pins in NGINX_BASE, not from anything built here. Nothing
+# in this image uses it, and its dependencies are a recurring source of CVE
+# reports against an image that only needs the Fastly module installed above.
+#
+# ssdeep (libfuzzy) and yajl are linked by ModSecurity and by nothing else in
+# the image, so they go too. libxml2, libcurl and libmaxminddb stay: njs,
+# OpenTelemetry and GeoIP2 link them as well.
+#
+# The final check fails the build if anything survives, so a future base image
+# that relocates these paths cannot quietly reintroduce ModSecurity.
+RUN rm -rf \
+      /usr/local/modsecurity \
+      /etc/nginx/modsecurity \
+      /etc/nginx/owasp-modsecurity-crs \
+      /etc/nginx/modules/ngx_http_modsecurity_module.so \
+      /opt/modsecurity \
+      /var/log/audit \
+      /usr/local/bin/ssdeep \
+      /usr/local/include/fuzzy.h \
+      /usr/local/lib/libfuzzy.la \
+      /usr/local/lib/libfuzzy.so \
+      /usr/local/lib/libfuzzy.so.2 \
+      /usr/local/lib/libfuzzy.so.2.1.0 \
+      /usr/local/share/man/man1/ssdeep.1 \
+    && apk del --no-cache yajl \
+    && if find / \( -iname '*modsec*' -o -iname '*ssdeep*' -o -iname '*fuzzy*' -o -iname '*yajl*' \) 2>/dev/null | grep -q .; then \
+         echo "ERROR: ModSecurity artifacts remain in the image:" >&2; \
+         find / \( -iname '*modsec*' -o -iname '*ssdeep*' -o -iname '*fuzzy*' -o -iname '*yajl*' \) 2>/dev/null >&2; \
+         exit 1; \
+       fi
+
+# The controller renders nginx.conf from this template and emits the
+# ModSecurity `load_module` line whenever `enable-modsecurity` is set in the
+# controller ConfigMap, or the nginx.ingress.kubernetes.io/enable-modsecurity
+# annotation is set on an Ingress. With the module deleted that would fail as a
+# bare dlopen() error that reads like a broken image, so point the line at a
+# file that does not exist instead: NGINX then stops with the missing path,
+# which names the actual cause.
+#
+# `grep` fails the build if the upstream template stops matching, so the guard
+# cannot silently go missing.
+RUN grep -qxF 'load_module /etc/nginx/modules/ngx_http_modsecurity_module.so;' /etc/nginx/template/nginx.tmpl \
+    && sed -i 's@^load_module /etc/nginx/modules/ngx_http_modsecurity_module\.so;$@# ModSecurity has been removed from this image. The Fastly Next-Gen WAF\n# module (ngx_http_sigsci_module) provides WAF functionality instead.\n# Unset enable-modsecurity to start NGINX.\ninclude /etc/nginx/MODSECURITY-REMOVED-FROM-THIS-IMAGE-unset-enable-modsecurity.conf;@' \
+      /etc/nginx/template/nginx.tmpl
 
 # Switch back to the non-privileged user for executing nginx at runtime.
 # NOTE: Upstream uses `www-data`, but Chainguard uses `nonroot`. 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,39 @@ Use `Dockerfile.nginxinc` if you want to add the Signal Sciences NGINX module in
 
 Prebuilt images are hosted here: https://hub.docker.com/repository/docker/signalsciences/sigsci-nginxinc-ingress-controller
 
+***Chainguard fork***
+`kubernetes/ingress-nginx` was archived on March 24, 2026. `Dockerfile.chainguard` builds against the Chainguard fork (https://github.com/chainguard-forks/ingress-nginx) instead.
+
+Prebuilt images are hosted here: https://hub.docker.com/repository/docker/signalsciences/sigsci-nginx-ingress-controller-chainguard
+
+## ModSecurity is not available in the Chainguard image
+
+The upstream NGINX base image ships ModSecurity, the OWASP Core Rule Set and the
+`ngx_http_modsecurity_module` NGINX module. `Dockerfile.chainguard` deletes all of
+them: the Fastly Next-Gen WAF module provides WAF functionality in this image, and
+carrying a second WAF only adds size and vulnerability reports for code that nothing
+uses.
+
+As a result, ModSecurity cannot be turned on in this image. Either of these will
+stop NGINX from starting:
+
+* `enable-modsecurity: "true"` in the controller ConfigMap
+* the `nginx.ingress.kubernetes.io/enable-modsecurity: "true"` Ingress annotation
+
+The remaining ModSecurity settings (`enable-owasp-modsecurity-crs`,
+`nginx.ingress.kubernetes.io/enable-owasp-core-rules`, `modsecurity-snippet`,
+`modsecurity-transaction-id`) only take effect once ModSecurity is enabled, so on
+their own they are ignored exactly as they were before.
+
+If ModSecurity is enabled, NGINX fails its configuration check with:
+
+```
+nginx: [emerg] open() "/etc/nginx/MODSECURITY-REMOVED-FROM-THIS-IMAGE-unset-enable-modsecurity.conf" failed (2: No such file or directory)
+```
+
+Unset the setting to start NGINX. All of these default to off, so an installation
+that has not deliberately enabled ModSecurity is unaffected.
+
 ## Helm install instructions with override file
 
 The following are steps to install [kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx) via helm using the sigsci-values.yaml override file. This adds the custom sigsci-nginx-ingress-controller and sigsci-agent.


### PR DESCRIPTION
Three changes to `Dockerfile.chainguard` and its workflow.

**Chainguard fork tag** — `v1.15.7` → `v1.15.10`, the current `controller-*` release of the fork.

**Go toolchain** — the controller is now compiled with Go 1.26.6 instead of the 1.26.2 the fork pins in `GOLANG_VERSION`. `go.mod` only requires `go 1.26.1`, so this is a patch-release update with no source changes. Passed as a `make build` override; the fork's own file is untouched.

**ModSecurity** — removed from the image, along with the OWASP Core Rule Set and the two libraries (`ssdeep`, `yajl`) that nothing else in the image links. It arrives pre-built in the NGINX base image that the fork pins in `NGINX_BASE`; nothing here uses it, and the Signal Sciences module provides WAF functionality. `libxml2`, `libcurl` and `libmaxminddb` are kept, since njs, OpenTelemetry and GeoIP2 also link them.

Two build-time guards keep this from regressing quietly: the build fails if any ModSecurity artifact survives the removal, and it also fails if the NGINX config template stops matching the line the guard rewrites.

Also in here: `TAG` is now passed to `make build`, so the controller reports the version it was built for. It previously reported `v1.15.5` regardless of the image tag, because the fork does not bump its `TAG` file per release.

The README documents that ModSecurity cannot be enabled in this image, and what happens if it is.

### Verification

Built end to end against `controller-v1.15.10` for arm64:

- no ModSecurity artifacts remain
- `nginx -t` passes with the Signal Sciences module loading
- the controller reports `Release: v1.15.10` and `go1.26.6`
- image filesystem drops from 253.2 MiB to 194.9 MiB

Enabling `enable-modsecurity` now stops NGINX with a message naming the cause instead of a bare `dlopen()` failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)